### PR TITLE
[tk29]  Melhoria na geração e na disponibilização dos relatórios

### DIFF
--- a/tools.py
+++ b/tools.py
@@ -561,13 +561,13 @@ class ArticleReport(object):
         url = 'http://articlemeta.scielo.org/api/v1/article/' \
               '?collection={}&code={}&format=xmlwos\n'.format(
                     self.collection, self.code)
-        sep = '\n'+'='*10+'\n'
+        sep = '\n'*2
         content = []
         xml = validated.display(numbered)
         if numbered:
-            content = [now, url, errors, xml]
+            content = [now, url, 'ERRORS\n'+'='*6, errors, '-'*30, xml]
         else:
-            content = [xml, now, url, errors]
+            content = [xml, '-'*30, now, url, 'ERRORS\n'+'='*6, errors]
 
         write_file(report_filename, sep.join(content))
 

--- a/tools.py
+++ b/tools.py
@@ -477,7 +477,7 @@ class ValidatedXML(object):
         else:
             self._original_xml = XML(textxml)
             self._pretty_xml = XML(self._original_xml.pretty_text)
-            self.errors = self.validate()
+            self.errors = self._validate()
 
     @property
     def xml_schema(self):
@@ -494,12 +494,12 @@ class ValidatedXML(object):
         if self._original_xml is not None:
             return self._original_xml.parsed
 
-    def validate(self):
+    def _validate(self):
         # Validating well formed
         if len(self._pretty_xml.parse_errors) > 0:
             return self._pretty_xml.parse_errors
 
-        # Validating agains schema
+        # Validating against schema
         try:
             if self.xml_schema.validate(self._pretty_xml.parsed):
                 return []


### PR DESCRIPTION
Mantidas as interfaces, no entanto, seu conteúdo foi remodelado:
- class `XMLValidator`
  - novo atribuot `_get_xml` 
  - remodelado o conteúdo do atributo `validate_xml`
- `send_to_ftp`
  - inclusão de uma chamada a uma função que envia novos relatórios: `send_collections_reports`

Geração dos relatórios: 0 ou 1 relatório de erro por Artigo
---
Os relatórios dos artigos estão organizado em pastas: 
`<ROOT_REPORTS_DIR>/<collection>/<issn>/<pid>.err.txt
`
As modificações feitas no conteúdo de `XMLValidator` para separar as responsabilidades:
- `XML`: 
  - carregar o textxml, gerando um ElementTree ("parsed xml")
  - fornecer um "pretty xml"
- `ValidatedXML`: 
  - valida "pretty xml" quanto à estrutura
  - valida "pretty xml" quanto ao Schema
  - fornece o "parsed xml" do xml original quando não há erros
- `ArticleReport`: 
  - a partir de `XMLValidated.errors` gera o relatório do artigo
  
Disponibilização dos relatórios
---
Os relatórios dos artigos estão organizado em pastas: 
`<ROOT_REPORTS_DIR>/<collection>/<issn>/<pid>.err.txt`.
A função `send_collections_reports` gera um zip por coleção dos arquivos que estão em `<ROOT_REPORTS_DIR>`, guarda este zip na pasta "collections_reports", com o nome `<collection>.zip`,  transfere os `<collection>_YYYYMMDD.zip` para o servidor de ftp, apagando o `<collection>.zip`.
Novas classes usadas neste trecho:
- FTPService
- CollectionReports



Como usar
---
Os comandos abaixo validam o XML e geram o relatório de erros na pasta **xml_errors**
 
```
>>> import tools
>>> v = tools.XMLValidator()
>>> v.validate_xml('prt', 'S0430-50272013000100003')
```

O comando abaixo compacta os relatórios da pasta **xml_errors** e os envia para o ftp indicado no comando.

```
>>> tools.send_collections_reports(
           'ftp.server.xx', 'user', 'password', local_path='local', remote_path='remote')
```
Fixes #29
