### PR TITLE
Cria uma função para remover contrib-id e condiciona esta remoção se houver erro na validação

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests==2.18.1
 pymongo==3.4.0
 lxml==3.8.0
--e git+https://github.com/scieloorg/export-sci@3.1#egg=exportsci
+-e git+https://github.com/scieloorg/export-sci@3.2#egg=exportsci


### PR DESCRIPTION
A tag não está prevista na XSD em uso.
A tag contrib-id foi inserida para uso do scielo_articles.zip.